### PR TITLE
Draft schedule

### DIFF
--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -3,7 +3,7 @@ title: Virtual Workshop Schedule
 nav_title: Schedule
 ---
 
-A preliminary schedule for the May 2023 "Introduction to Single-Cell RNA-Seq" Data Lab Virtual Training Workshop appears below.s
+A preliminary schedule for the May 2023 "Introduction to Single-Cell RNA-Seq" Data Lab Virtual Training Workshop appears below.
 
 
 *Note: All times are [EDT (UTC−04:00)](https://www.timeanddate.com/time/zones/edt).*
@@ -21,12 +21,11 @@ A preliminary schedule for the May 2023 "Introduction to Single-Cell RNA-Seq" Da
 |             | [Exercise: Introduction to R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_02-intro_to_R.Rmd)  | |
 |             | [Exercise: Introduction to the `tidyverse`, Part 1](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_03a-intro_to_tidyverse.Rmd)  | |
 |             | [Exercise: Introduction to the `tidyverse`, Part 2](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_03b-intro_to_tidyverse.Rmd)  | |
-
-|             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
+|             | [Consultation session](workshop-structure.md#consultation-sessions) and exercises | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
 | 5:00  PM    | End             |
 | **Day 2**   | **2023-05-16**  <br> _**Introduction to Single-cell RNA-seq, Day 1**_ |
 | 12:00 PM    | Introduction <br> | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
-| 12:30 PM    | [Quantification and general QC of tag-based data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/01-scRNA_quant_qc.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
+| 12:30 PM    | [scRNA-seq quantification with Alevin](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/01-scRNA_quant_qc.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
 | 1:30 PM     | [Importing data and filtering cells](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/02-filtering_scRNA.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 2:30 PM     | [Normalization of expression data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/03-normalizing_scRNA.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 3:30 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
@@ -41,7 +40,7 @@ A preliminary schedule for the May 2023 "Introduction to Single-Cell RNA-Seq" Da
 |             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
 | 5:00  PM    | End             |
 | **Day 4**   | **2023-05-18**  <br> _**Introduction to Single-cell RNA-seq, Day 3**_ | |
-| 12:00 PM    | [Cell type annotation](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/06-celltype_annotation.Rmd) |  Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 12:00 PM    | [Cell type annotation](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/06-celltype_annotation.nb.html) |  Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 2:30 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
 |             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use)|
 |             | [Exercise: scRNA-seq cell type annotation](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_03-celltype.Rmd) | |

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -22,7 +22,8 @@ A preliminary schedule for the May 2023 "Introduction to Single-Cell RNA-Seq" Da
 |             | [Exercise: Introduction to the `tidyverse`, Part 1](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_03a-intro_to_tidyverse.Rmd)  | |
 |             | [Exercise: Introduction to the `tidyverse`, Part 2](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_03b-intro_to_tidyverse.Rmd)  | |
 |             | [Consultation session](workshop-structure.md#consultation-sessions) and exercises | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
-| 5:00  PM    | End             |
+| 5:00  PM    | *Adjourn for the day*             |
+| | |         |
 | **Day 2**   | **2023-05-16**  <br> _**Introduction to Single-cell RNA-seq, Day 1**_ |
 | 12:00 PM    | Introduction <br> | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 12:30 PM    | [scRNA-seq quantification with Alevin](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/01-scRNA_quant_qc.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
@@ -31,21 +32,24 @@ A preliminary schedule for the May 2023 "Introduction to Single-Cell RNA-Seq" Da
 | 3:30 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
 |             | [Exercise: scRNA-seq quantification](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_01-scrna_quant.Rmd) | |
 |             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
-| 5:00  PM    | End             |
+| 5:00  PM    | *Adjourn for the day*             |
+| | |         |
 | **Day 3**   | **2023-05-17**  <br> _**Introduction to Single-cell RNA-seq, Day 2**_ |
 | 12:00 PM    | [Dimension reduction & visualization](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/04-dimension_reduction_scRNA.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
 | 1:30 PM     | [Clustering and marker identification](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/05-clustering_markers_scRNA.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 3:00 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
 |             | [Exercise: scRNA-seq clustering](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_02-scrna_clustering.Rmd) | |
 |             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
-| 5:00  PM    | End             |
+| 5:00  PM    | *Adjourn for the day*             |
+| | |    |
 | **Day 4**   | **2023-05-18**  <br> _**Introduction to Single-cell RNA-seq, Day 3**_ | |
 | 12:00 PM    | [Cell type annotation](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/06-celltype_annotation.nb.html) |  Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 2:30 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
 |             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use)|
 |             | [Exercise: scRNA-seq cell type annotation](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_03-celltype.Rmd) | |
-| 5:00 PM     | End ||
+| 5:00  PM    | *Adjourn for the day*             |
+| | |
 | **Day 5**   | **2023-05-19**  <br> _**Consultation and Presentations**_ |
 | 12:00 PM    | [Consultation session](workshop-structure.md#consultation-sessions)  | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
 | 2:30 PM     | [Participant presentations begin](workshop-structure.md#presentations) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
-| 5:00 PM     | Adjourn   |
+| 5:00 PM     | *Adjourn*   |

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -3,15 +3,42 @@ title: Virtual Workshop Schedule
 nav_title: Schedule
 ---
 
-<!--See an example from a past virtual workshop here: https://github.com/AlexsLemonade/2020-may-training/wiki/Schedule --> 
+A preliminary schedule for the May 2023 "Introduction to Single-Cell RNA-Seq" Data Lab Virtual Training Workshop appears below.
 
-| Time        | Topic                                          |
-|-------------|------------------------------------------------|
-| **Day 1**   | **Date** <br> [Module]()                      |
-| 12:00 PM    | Welcome, Introductions and Getting Started     <br>[Welcome Slides (PDF)](../slides/ Workshop_Introduction.pdf)|
-| 5:00        | End             |
-| **Day 2**   | **Date**  | 
-| **Day 3**   | **Date**  |               
-| **Day 4**   | **Date**  | 
-| **Day 5**   | **Date**  |     
-| 5:00        | Adjourn   |
+
+*Note: All times are [EDT (UTC−04:00)](https://www.timeanddate.com/time/zones/edt).*
+
+
+| Time        | Topic                             | Location |
+|-------------|--------------------------------------------|----------------|
+| **Day 1**   | **2023-05-15** <br> _**Introduction to R and the Tidyverse**_                 |
+| 12:00 PM    | Welcome, Introductions and Getting Started  | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 1:00 PM     | Introduction to base R | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
+| 2:30 PM     | Introduction to `ggplot2` | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 3:30 PM     | Introduction to the tidyverse | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 4:30 PM     | Questions and introduction to the exercises | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
+|             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
+| 5:00  PM    | End             |
+| **Day 2**   | **2023-05-16**  <br> _**Introduction to Single-cell RNA-seq, Day 1**_ |
+| 12:00 PM    | Introduction <br> | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 12:30 PM    | Quantification and general QC of tag-based data | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
+| 1:30 PM     | Importing data and filtering cells | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 2:30 PM     | Normalization of expression data| Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 3:30 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
+|             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
+| 5:00  PM    | End             |
+| **Day 3**   | **2023-05-17**  <br> _**Introduction to Single-cell RNA-seq, Day 2**_ |
+| 12:00 PM    | Dimension reduction & visualization | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
+| 1:30 PM     | Clustering and marker identification | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 3:00 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
+|             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
+| 5:00  PM    | End             |
+| **Day 4**   | **2023-05-18**  <br> _**Introduction to Single-cell RNA-seq, Day 3**_ | |
+| 12:00 PM    | Cell type annotation |  Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 2:30 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
+|             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use)|
+| 5:00 PM     | End ||
+| **Day 5**   | **2023-05-19**  <br> _**Consultation and Presentations**_ |
+| 12:00 PM    | [Consultation session](workshop-structure.md#consultation-sessions)  | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
+| 2:30 PM     | [Participant presentations begin](workshop-structure.md#presentations) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 5:00 PM     | Adjourn   |

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -3,7 +3,7 @@ title: Virtual Workshop Schedule
 nav_title: Schedule
 ---
 
-A preliminary schedule for the May 2023 "Introduction to Single-Cell RNA-Seq" Data Lab Virtual Training Workshop appears below.
+A preliminary schedule for the May 2023 "Introduction to Single-Cell RNA-Seq" Data Lab Virtual Training Workshop appears below.s
 
 
 *Note: All times are [EDT (UTC−04:00)](https://www.timeanddate.com/time/zones/edt).*
@@ -13,30 +13,38 @@ A preliminary schedule for the May 2023 "Introduction to Single-Cell RNA-Seq" Da
 |-------------|--------------------------------------------|----------------|
 | **Day 1**   | **2023-05-15** <br> _**Introduction to R and the Tidyverse**_                 |
 | 12:00 PM    | Welcome, Introductions and Getting Started  | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
-| 1:00 PM     | Introduction to base R | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
-| 2:30 PM     | Introduction to `ggplot2` | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
-| 3:30 PM     | Introduction to the tidyverse | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 1:00 PM     | [Introduction to base R](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/01-intro_to_base_R.nb.html)  | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
+| 2:30 PM     | [Introduction to `ggplot2`](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 3:30 PM     | [Introduction to the `tidyverse`](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/03-intro_to_tidyverse.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 4:30 PM     | Questions and introduction to the exercises | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
+|             | [Exercise: Introduction to base R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_01-intro_to_base_R.Rmd)  | |
+|             | [Exercise: Introduction to R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_02-intro_to_R.Rmd)  | |
+|             | [Exercise: Introduction to the `tidyverse`, Part 1](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_03a-intro_to_tidyverse.Rmd)  | |
+|             | [Exercise: Introduction to the `tidyverse`, Part 2](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_03b-intro_to_tidyverse.Rmd)  | |
+
 |             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
 | 5:00  PM    | End             |
 | **Day 2**   | **2023-05-16**  <br> _**Introduction to Single-cell RNA-seq, Day 1**_ |
 | 12:00 PM    | Introduction <br> | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
-| 12:30 PM    | Quantification and general QC of tag-based data | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
-| 1:30 PM     | Importing data and filtering cells | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
-| 2:30 PM     | Normalization of expression data| Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 12:30 PM    | [Quantification and general QC of tag-based data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/01-scRNA_quant_qc.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
+| 1:30 PM     | [Importing data and filtering cells](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/02-filtering_scRNA.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 2:30 PM     | [Normalization of expression data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/03-normalizing_scRNA.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 3:30 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
+|             | [Exercise: scRNA-seq quantification](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_01-scrna_quant.Rmd) | |
 |             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
 | 5:00  PM    | End             |
 | **Day 3**   | **2023-05-17**  <br> _**Introduction to Single-cell RNA-seq, Day 2**_ |
-| 12:00 PM    | Dimension reduction & visualization | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
-| 1:30 PM     | Clustering and marker identification | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 12:00 PM    | [Dimension reduction & visualization](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/04-dimension_reduction_scRNA.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
+| 1:30 PM     | [Clustering and marker identification](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/05-clustering_markers_scRNA.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 3:00 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
+|             | [Exercise: scRNA-seq clustering](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_02-scrna_clustering.Rmd) | |
 |             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
 | 5:00  PM    | End             |
 | **Day 4**   | **2023-05-18**  <br> _**Introduction to Single-cell RNA-seq, Day 3**_ | |
-| 12:00 PM    | Cell type annotation |  Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 12:00 PM    | [Cell type annotation](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/06-celltype_annotation.Rmd) |  Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 2:30 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
 |             | Exercise and [consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use)|
+|             | [Exercise: scRNA-seq cell type annotation](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_03-celltype.Rmd) | |
 | 5:00 PM     | End ||
 | **Day 5**   | **2023-05-19**  <br> _**Consultation and Presentations**_ |
 | 12:00 PM    | [Consultation session](workshop-structure.md#consultation-sessions)  | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |


### PR DESCRIPTION
Closes #7 

This PR creates the draft version of the schedule. Some places to note:
- I went ahead and included all the intro R exercise notebooks here, but should I only include the `02` notebook?
- We don't yet have a rendered cell type annotation notebook in `training-modules`, so I couldn't link to an HTML preview. For now, I've just linked the Rmd, we can circle back to update it as part of #9.
- For cell typing, I put it as only 2.5 hours into the schedule. Want more time in the schedule for that?